### PR TITLE
Release support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dymosim.lib
 *.fmu
 *.h
 *.bak-mo
+
+/Support/.idea

--- a/Support/addCopyright.py
+++ b/Support/addCopyright.py
@@ -13,14 +13,21 @@ omc.sendExpression("loadModel(Modelica)")
 omc.sendExpression('loadFile("C:\dev\OSS\OpenIPSL_Repo\OpenIPSL\package.mo")')
 list_models = omc.sendExpression('getClassNames(OpenIPSL,recursive=true)')
 
-newCopyrightFile  = open('copyrightStatement')
+newCopyrightFile = open('copyrightStatement')
 newCopyright = newCopyrightFile.read()
 
 # Loop on all models:
-for model in list_models:
-    #Get the current annotation
+for model in list_models[0:1]:
+    # Get the current annotation
     anno = omc.sendExpression("getDocumentationAnnotation(%s)" % (model))
-    omc.sendExpression("setDocumentationAnnotation(%s,%s,%s,%s)" % (model,anno[0],newCopyright,anno[2]))
+    info = anno[0].replace('"', '\\"')
 
-omc.sendExpression("save(OpenIPSL)")
-
+    cmdString = 'setDocumentationAnnotation(%s,info="%s",revisions="%s")' % (model, info, newCopyright)
+    print cmdString
+    try:
+        omc.sendExpression(cmdString)
+        omc.sendExpression("save(%s)" % model)
+    except:
+        print model
+        print info
+        raise

--- a/Support/addCopyright.py
+++ b/Support/addCopyright.py
@@ -1,0 +1,26 @@
+# Apply Copyright in all .mo files of the library
+
+import sys
+import os
+from OMPython import OMCSession
+
+# Start OMC session and load MSL
+
+omc = OMCSession()
+omc.sendExpression("loadModel(Modelica)")
+
+# Load OpenIPSL and get all models
+omc.sendExpression('loadFile("C:\dev\OSS\OpenIPSL_Repo\OpenIPSL\package.mo")')
+list_models = omc.sendExpression('getClassNames(OpenIPSL,recursive=true)')
+
+newCopyrightFile  = open('copyrightStatement')
+newCopyright = newCopyrightFile.read()
+
+# Loop on all models:
+for model in list_models:
+    #Get the current annotation
+    anno = omc.sendExpression("getDocumentationAnnotation(%s)" % (model))
+    omc.sendExpression("setDocumentationAnnotation(%s,%s,%s,%s)" % (model,anno[0],newCopyright,anno[2]))
+
+omc.sendExpression("save(OpenIPSL)")
+

--- a/Support/copyrightStatement
+++ b/Support/copyrightStatement
@@ -1,5 +1,14 @@
 <html>
 <!--DISCLAIMER-->
+<p>Copyright 2016 SmarTS Lab (Sweden)</p>
+<ul>
+<li>SmarTS Lab, research group at KTH: <a href=\"https://www.kth.se/en\">https://www.kth.se/en</a></li>
+</ul>
+<p>The authors can be contacted by email: <a href=\"mailto:luigiv@kth.se\">luigiv@kth.se</a></p>
+
+<p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. </p>
+<p>If a copy of the MPL was not distributed with this file, You can obtain one at <a href=\"http://mozilla.org/MPL/2.0/\"> http://mozilla.org/MPL/2.0</a>.</p>
+
 <p>Copyright 2015-2016 RTE (France), SmarTS Lab (Sweden), AIA (Spain) and DTU (Denmark)</p>
 <ul>
 <li>RTE: <a href=\"http://www.rte-france.com\">http://www.rte-france.com</a></li>


### PR DESCRIPTION
Adding /Support folder to contain a set of script to assist the release of the library. The first script is to automate the update of the copyright information. 

The script is supposedly working but introduces errors in the syntax of the files. See #47 
Because of that the PR is sent to a separate branch waiting for more info from OM. 