### PR TITLE
Updating PSAT AVR Type III to remove initialization parameters

### DIFF
--- a/OpenIPSL/Electrical/Controls/PSAT/AVR/AVRtypeIII.mo
+++ b/OpenIPSL/Electrical/Controls/PSAT/AVR/AVRtypeIII.mo
@@ -1,16 +1,14 @@
 within OpenIPSL.Electrical.Controls.PSAT.AVR;
 model AVRtypeIII
-  parameter Real vref=1;
-  parameter Real v0=1 "initial voltage after power flow";
+
   parameter Real vfmax=5;
   parameter Real vfmin=-5;
   parameter Real K0=20 "regulator gain";
   parameter Real T2=0.1 "regulator pole";
   parameter Real T1=0.45 "Regulator zero";
   parameter Real Te=0.1 "Field circuit time constant";
-  parameter Real vf0 "Initial field voltage";
   parameter Real Tr=0.0015 "Measurement time constant";
-  parameter Real s0;
+
   Real vm;
   Real vr;
   Real vf1;
@@ -22,7 +20,7 @@ model AVRtypeIII
   Modelica.Blocks.Interfaces.RealInput v(start=1) annotation (Placement(
       visible=true,
       transformation(
-        origin={-157.972,50},
+        origin={-119.972,50},
         extent={{-20.0,-20.0},{20.0,20.0}},
         rotation=0),
       iconTransformation(
@@ -40,14 +38,29 @@ model AVRtypeIII
         extent={{-10.0,-10.0},{10.0,10.0}},
         rotation=0)));
   Modelica.Blocks.Interfaces.RealInput vs annotation (Placement(transformation(extent={{-140,-60},{-100,-20}}), iconTransformation(extent={{-140,-60},{-100,-20}})));
+  Modelica.Blocks.Interfaces.RealInput vf0(start=1) annotation (Placement(
+      visible=true,
+      transformation(
+        origin={0.028,120},
+        extent={{-20.0,-20.0},{20.0,20.0}},
+        rotation=-90),
+      iconTransformation(
+        origin={0,120},
+        extent={{-20.0,-20.0},{20.0,20.0}},
+        rotation=-90)));
+protected
+  parameter Real vref(fixed=false);
+  parameter Real s0(fixed=false);
 initial equation
+  vref = v;
+  s0 = vs;
   vf1 = vf0;
-  vm = v0;
+  vm = v;
   vr = K0*(1 - T1/T2)*(vref + vs - vm);
 equation
   der(vm) = (v - vm)/Tr;
   der(vr) = (K0*(1 - T1/T2)*(vref + vs - vm) - vr)/T2;
-  der(vf1) = ((vr + K0*(T1/T2)*(vref + vs - vm) + vf0)*(1 + s0*(v/v0 - 1)) - vf1)/Te;
+  der(vf1) = ((vr + K0*(T1/T2)*(vref + vs - vm) + vf0)*(1 + s0*(v/vm - 1)) - vf1)/Te;
   limiter1.u = vf1;
   limiter1.y = vf;
   annotation (Icon(
@@ -56,27 +69,37 @@ equation
         preserveAspectRatio=false,
         initialScale=0.1,
         grid={10,10}),
-      graphics={Rectangle(
+      graphics={
+        Rectangle(
           visible=true,
           fillColor={255,255,255},
-          extent={{-100.0,-100.0},{100.0,100.0}}),Text(
+          extent={{-100.0,-100.0},{100.0,100.0}}),
+        Text(
           visible=true,
           origin={1.5941,2.9728},
           fillPattern=FillPattern.Solid,
           extent={{-31.5941,-24.9719},{31.5941,24.9719}},
           textString="AVRtypeIII",
-          fontName="Arial"),Text(
+          fontName="Arial"),
+        Text(
           visible=true,
           origin={-77.3525,52.4473},
           fillPattern=FillPattern.Solid,
           extent={{-17.3525,-17.5527},{17.3525,17.5527}},
           textString="v",
-          fontName="Arial"),Text(
+          fontName="Arial"),
+        Text(
           origin={-74.7671,-32.7013},
           fillPattern=FillPattern.Solid,
           extent={{-11.7427,-9.8104},{11.7427,9.8104}},
           fontName="Arial",
           textString="vs",
+          lineColor={0,0,0}),
+        Text(
+          origin={-2.3525,77.4473},
+          extent={{-12.3525,-12.5527},{12.3525,12.5527}},
+          fontName="Arial",
+          textString="vf0",
           lineColor={0,0,0})},
       origin={84.2416,-0.0},
       fillPattern=FillPattern.Solid,

--- a/OpenIPSL/Examples/Machines/PSAT/Order3test2_AVR.mo
+++ b/OpenIPSL/Examples/Machines/PSAT/Order3test2_AVR.mo
@@ -21,8 +21,7 @@ model Order3test2_AVR
         origin={-31.6887,-10.7513},
         extent={{-10.0,-10.0},{10.0,10.0}},
         rotation=0)));
-  OpenIPSL.Electrical.Controls.PSAT.AVR.AVRtypeIII AVRtypeIII1(s0=0, vf0=2.61819)
-    annotation (Placement(visible=true, transformation(
+  OpenIPSL.Electrical.Controls.PSAT.AVR.AVRtypeIII AVRtypeIII1 annotation (Placement(visible=true, transformation(
         origin={-70,-5.99998},
         extent={{-10,-10},{10,10}},
         rotation=0)));
@@ -33,6 +32,7 @@ equation
   connect(AVRtypeIII1.v, order3_Inputs_Outputs1.v) annotation (Line(points={{-82,-0.99998},{-88,-0.99998},{-88,10},{-15,10},{-15,-7.7513},{-20.6887,-7.7513}}, color={0,0,127}));
   connect(order3_Inputs_Outputs1.pm0, order3_Inputs_Outputs1.pm) annotation (Line(points={{-39.6887,-21.7513},{-39.6887,-24},{-45,-24},{-45,-15.7513},{-41.6887,-15.7513}}, color={0,0,127}));
   connect(const.y, AVRtypeIII1.vs) annotation (Line(points={{-88.5,-10},{-82,-10},{-82,-9.99998}}, color={0,0,127}));
+  connect(AVRtypeIII1.vf0, order3_Inputs_Outputs1.vf0) annotation (Line(points={{-70,6.00002},{-70,12},{-39.6887,12},{-39.6887,0.2487}}, color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(
         extent={{-100,-100},{100,100}},

--- a/OpenIPSL/Examples/Machines/PSAT/Order4test2_AVR.mo
+++ b/OpenIPSL/Examples/Machines/PSAT/Order4test2_AVR.mo
@@ -3,8 +3,7 @@ model Order4test2_AVR
 
   extends OpenIPSL.Examples.BaseTest;
   extends Modelica.Icons.Example;
-  OpenIPSL.Electrical.Controls.PSAT.AVR.AVRtypeIII AVRtypeIII1(s0=0, vf0=1.0641)
-    annotation (Placement(visible=true, transformation(
+  OpenIPSL.Electrical.Controls.PSAT.AVR.AVRtypeIII AVRtypeIII1 annotation (Placement(visible=true, transformation(
         origin={-67,5},
         extent={{-10,-10},{10,10}},
         rotation=0)));
@@ -30,6 +29,7 @@ equation
   connect(AVRtypeIII1.v, order4_Inputs_Outputs.v) annotation (Line(points={{-79,10},{-87,10},{-87,20},{-10,20},{-10,3},{-16,3}}, color={0,0,127}));
   connect(order4_Inputs_Outputs.pm0, order4_Inputs_Outputs.pm) annotation (Line(points={{-35,-11},{-35,-13},{-41,-13},{-41,-5},{-37,-5}}, color={0,0,127}));
   connect(order4_Inputs_Outputs.p, bus.p) annotation (Line(points={{-16,0.04964},{-8,0.04964},{-8,0},{0,0}}, color={0,0,255}));
+  connect(AVRtypeIII1.vf0, order4_Inputs_Outputs.vf0) annotation (Line(points={{-67,17},{-67,23},{-35,23},{-35,11}}, color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(
         extent={{-100,-100},{100,100}},


### PR DESCRIPTION
- Removed parameters s0, v0 and vref from the AVR model
- Updated examples using this AVR model