### PR TITLE
Fixing the rotation of the package logo

### DIFF
--- a/OpenIPSL/package.mo
+++ b/OpenIPSL/package.mo
@@ -24,5 +24,5 @@ annotation (
 <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. </p>
 <p>If a copy of the MPL was not distributed with this file, You can obtain one at <a href=\"http://mozilla.org/MPL/2.0/\"> http://mozilla.org/MPL/2.0</a>.</p>
 </html>"),
-  Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={Bitmap(extent={{-100,100},{100,-100}}, fileName="modelica://OpenIPSL/Resources/Images/OpenIPSL_Logo.png")}));
+  Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={Bitmap(extent={{-100,-100},{100,100}}, fileName="modelica://OpenIPSL/Resources/Images/OpenIPSL_Logo.png")}));
 end OpenIPSL;


### PR DESCRIPTION
Dymola 2016FD01 and onwards are finally displaying bitmaps correctly with the correct {{bottomleft},{topright}} coordinates. They did not before which means Icons added and saved with older versions will be saved incorrectly. This PR fixes the coordinates.