### PR TITLE
Documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ As such, the purpose of OpenIPSL are to be used as a research library (therefore
 ## Notice to Users:
 This project encompasses the development of a Modelica library for power system simulation.
 As such, there are no solver tools provided in this repository (no Power Flow Solvers, no Time-Domain solvers, etc.).
-You can find more information in our [**documentation**](http://openipsl.readthedocs.io/).
+You can find more information in our [**documentation**](http://openipsl.readthedocs.io/en/latest/user-guide/get-started.html).
 
 The OpenIPSL contains the models developed by SmarTS Lab during the iTesla project, and necesssary models that were implemented by RTE and AIA, that we can maintain.
 Note that several models have been removed from what it is available in iPSL (see [here](https://github.com/SmarTS-Lab/OpenIPSL/pull/10)).
@@ -28,7 +28,7 @@ Contributions can be of different nature, such as addition of a new component mo
 
 Please consult the [contribution guidelines](http://openipsl.readthedocs.io/en/latest/community/contributing.html).
 
-More information about our contributors can be found over [here](http://openipsl.readthedocs.io/en/latest/community/community-home.html). Don't hesitate to contact us. 
+More information about our contributors can be found over [here](http://openipsl.readthedocs.io/en/latest/community/community-home.html). Don't hesitate to contact us.
 
 ## Citing OpenIPSL in Publications:
 If you use OpenIPSL in your work or research, all we ask you in exchange is that you **cite the reference publications**, according to your use.

--- a/README.md
+++ b/README.md
@@ -13,17 +13,14 @@ As such, the purpose of OpenIPSL are to be used as a research library (therefore
 ## Notice to Users:
 This project encompasses the development of a Modelica library for power system simulation.
 As such, there are no solver tools provided in this repository (no Power Flow Solvers, no Time-Domain solvers, etc.).
-You can find more information in our [**documentation**](http://openipsl.readthedocs.io/en/latest/get-started.html).
+You can find more information in our [**documentation**](http://openipsl.readthedocs.io/).
 
 The OpenIPSL contains the models developed by SmarTS Lab during the iTesla project, and necesssary models that were implemented by RTE and AIA, that we can maintain.
 Note that several models have been removed from what it is available in iPSL (see [here](https://github.com/SmarTS-Lab/OpenIPSL/pull/10)).
 However, we have removed all models that are dependent on a specific software tool from the power systems domain that we don't have access for Software-to-Software validation, and those that require us access to closed standards that we don't have money to buy in order to maintain them (i.e. IEC Wind Turbine models).
 
 ## Documentation:
-Currently, we are developing an 'application guide' with examples how to use the library and documentation on many of the test networks developed by different people.
-Documentation on the use of this library will most likely be in the form of tutorials, as the use of Modelica tools is not the main interest of this fork.
-
-You can follow the following issues to know about our progress: [Application Guide](update link) and [Test Networks](update link).
+Please follow this link to our [**documentation**](http://openipsl.readthedocs.io/).
 
 ## Contributing:
 Contributions to the library are welcome and can be submitted in the form of pull requests to this repository.


### PR DESCRIPTION
Updated the documentation section, to point to the links in the readthedocs io.
The first link did not display the http://openipsl.readthedocs.io/ correctly.
I erased the old information about the application guide and test networks as it is not longer relevant.