### PR TITLE
Fixing the spelling of the standard "checkbox" annoation

### DIFF
--- a/OpenIPSL/Electrical/Branches/PwLine.mo
+++ b/OpenIPSL/Electrical/Branches/PwLine.mo
@@ -35,7 +35,7 @@ model PwLine "Model for a transmission Line based on the pi-equivalent circuit"
       group="Visualisation",
       __Dymola_compact=true,
       __Dymola_descriptionLabel=true),
-      choices(checkBox=true));
+      choices(checkbox=true,__Dymola_checkBox=true));
   OpenIPSL.Types.ActivePowerMega P12;
   OpenIPSL.Types.ActivePowerMega P21;
   OpenIPSL.Types.ReactivePowerMega Q12;

--- a/OpenIPSL/Electrical/Buses/Bus.mo
+++ b/OpenIPSL/Electrical/Buses/Bus.mo
@@ -19,7 +19,7 @@ model Bus "Bus model (2014/03/10)"
   parameter Boolean displayPF=true "Display voltage values:" annotation (Dialog(
       group="Visualisation",
       __Dymola_compact=true,
-      __Dymola_descriptionLabel=true), choices(checkBox=true));
+      __Dymola_descriptionLabel=true), choices(checkbox=true,__Dymola_checkBox=true));
 equation
   V = sqrt(p.vr^2 + p.vi^2);
   angle = atan2(p.vi, p.vr)*180/Modelica.Constants.pi;

--- a/OpenIPSL/Electrical/Buses/InfiniteBus.mo
+++ b/OpenIPSL/Electrical/Buses/InfiniteBus.mo
@@ -10,7 +10,7 @@ model InfiniteBus "PSAT Infinite Bus"
       group="Visualisation",
       __Dymola_compact=true,
       __Dymola_descriptionLabel=true),
-      choices(checkBox=true));
+      choices(checkbox=true,__Dymola_checkBox=true));
 equation
   p.vr = V_0*cos(angle_0*Modelica.Constants.pi/180);
   p.vi = V_0*sin(angle_0*Modelica.Constants.pi/180);

--- a/OpenIPSL/Interfaces/Generator.mo
+++ b/OpenIPSL/Interfaces/Generator.mo
@@ -7,7 +7,7 @@ partial model Generator
       group="Visualisation",
       __Dymola_compact=true,
       __Dymola_descriptionLabel=true),
-      choices(checkBox=true));
+      choices(checkbox=true,__Dymola_checkBox=true));
   OpenIPSL.Interfaces.PwPin pwPin annotation (Placement(transformation(extent={
             {100,-10},{120,10}}), iconTransformation(extent={{100,-10},{120,10}})));
   OpenIPSL.Types.ActivePowerMega P "Active power";


### PR DESCRIPTION
At the same time add the Dymola specific fallback since dymola does not support `checkbox` yet but only its own  (`__Dymola_`)`checkBox`