### PR TITLE
Add default prefixes definition for SystemBase

### DIFF
--- a/OpenIPSL/Electrical/SystemBase.mo
+++ b/OpenIPSL/Electrical/SystemBase.mo
@@ -26,5 +26,6 @@ record SystemBase "System Base Definition"
 No 'System Data' component is defined. A default component will be used, and generate a system base of 100 MVA, and a frequency of 50 Hz",
     Diagram(coordinateSystem(extent={{-120,-100},{120,100}},
         preserveAspectRatio=false,
-        initialScale=0.1)));
+        initialScale=0.1)),
+    defaultComponentPrefixes = "inner");
 end SystemBase;


### PR DESCRIPTION
This saves also one step in the tutorial ;-)