### PR TITLE
fix: Typo on PV and Wind Template Parameters

### DIFF
--- a/OpenIPSL/Electrical/Renewables/PSSE/PV.mo
+++ b/OpenIPSL/Electrical/Renewables/PSSE/PV.mo
@@ -12,8 +12,8 @@ extends OpenIPSL.Electrical.Essentials.pfComponent(
     final enableS_b=true);
 
   // Parameters for selection
-parameter Integer QFunctionality = 0 "PV Reactive Power Control Options" annotation (Dialog(group= "Reactive Power Control Options"), choices(choice=0 "Constant local PF control", choice=1 "Constant local Q control", choice=2 "Local V control", choice=3 "Local coordinated V/Q control", choice=4 "Plant level Q control", choice=5 "Plant level V control", choice=6 "Plant level Q control + local coordinated V/Q control", choice=7 "Plant level V control + local coordinated V/Q control"));
-parameter Integer PFunctionality = 0 "PV Real Power Control Options" annotation (Dialog(group= "Active Power Control Options", enable=(QFunctionality >=4)), choices(choice=0 "No governor response", choice=1 "Governor response with up and down regulation"));
+  parameter Integer QFunctionality = 0 "PV Reactive Power Control Options" annotation (Dialog(group= "Reactive Power Control Options"), choices(choice=0 "Constant local PF control", choice=1 "Constant local Q control", choice=2 "Local V control", choice=3 "Local coordinated V/Q control", choice=4 "Plant level Q control", choice=5 "Plant level V control", choice=6 "Plant level Q control + local coordinated V/Q control", choice=7 "Plant level V control + local coordinated V/Q control"));
+  parameter Integer PFunctionality = 0 "PV Real Power Control Options" annotation (Dialog(group= "Active Power Control Options", enable=(QFunctionality >=4)), choices(choice=0 "No governor response", choice=1 "Governor response with up and down regulation"));
 
   // Irradiance to Power parameter selection
   parameter Boolean Irr2Pow = false "Irradiance to Power Options" annotation (Dialog(group= "Irradiance to Power Add-On Capability"));

--- a/OpenIPSL/Electrical/Renewables/PSSE/Wind.mo
+++ b/OpenIPSL/Electrical/Renewables/PSSE/Wind.mo
@@ -12,7 +12,7 @@ extends OpenIPSL.Electrical.Essentials.pfComponent(
     final enableS_b=true);
 
   // Parameters for selection
-parameter Integer QFunctionality = 0 "Wind Reactive Power Control Options" annotation (Dialog(group= "Reactive Power Control Options"), choices(choice=0 "Constant local PF control", choice=1 "Constant local Q control", choice=2 "Local V control", choice=3 "Local coordinated V/Q control", choice=4 "Plant level Q control", choice=5 "Plant level V control", choice=6 "Plant level Q control + local coordinated V/Q control", choice=7 "Plant level V control + local coordinated V/Q control"));
+  parameter Integer QFunctionality = 0 "Wind Reactive Power Control Options" annotation (Dialog(group= "Reactive Power Control Options"), choices(choice=0 "Constant local PF control", choice=1 "Constant local Q control", choice=2 "Local V control", choice=3 "Local coordinated V/Q control", choice=4 "Plant level Q control", choice=5 "Plant level V control", choice=6 "Plant level Q control + local coordinated V/Q control", choice=7 "Plant level V control + local coordinated V/Q control"));
   parameter Integer PFunctionality = 0 "Wind Real Power Control Options" annotation (Dialog(group= "Active Power Control Options", enable=(QFunctionality >=4)), choices(choice=0 "No governor response", choice=1 "Governor response with up and down regulation"));
   parameter Integer TOscillation = 0 "Wind Torque Oscillation Option" annotation (Dialog(group= "Torsional Oscillation"), choices(choice=0 "Do not Emulate torsional oscillation", choice=1 "Emulated torsional oscillations in power output"));
   replaceable


### PR DESCRIPTION
QFunctionality and PFunctionality referred to BESS in Wind and PV templates.
